### PR TITLE
Update travis build and update to chefspec 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: ruby
 rvm:
   - 1.9.3
+sudo: false
+addons:
+  apt:
+    packages:
+      - libgecode-dev
+env: USE_SYSTEM_GECODE=1
 script: 
   - bundle exec foodcritic -f any .
   - bundle exec rspec --color --format progress

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-site :opscode
+source 'https://supermarket.chef.io'
 metadata
 cookbook 'composer', git: 'git://github.com/zircote/chef-composer'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,29 @@
 source "https://rubygems.org"
 
-gem 'berkshelf',  '~> 2.0'
-gem 'chefspec',   '~> 3.0'
+gem 'berkshelf',  '~> 3.0'
+gem 'ohai',       '~> 7.0'
+gem 'chefspec',   '4.3.0'
 gem 'foodcritic', '~> 3.0'
+
+# All these things are required to make sure it works
+# Because ruby dependency management sucks
+gem 'varia_model', '0.4.0'
+gem 'addressable', '~> 2.3.4'
+gem 'berkshelf-api-client', '~> 1.2'
+gem 'buff-config', '~> 1.0'
+gem 'buff-extensions', '~> 1.0'
+gem 'buff-shell_out', '~> 0.1'
+gem 'celluloid', '~> 0.16'
+gem 'celluloid-io', '~> 0.16.1'
+gem 'cleanroom', '~> 1.0'
+gem 'faraday', '0.9.1'
+gem 'net-http-persistent', '2.9.4'
+gem 'hitimes', '1.2.2'
+gem 'highline', '1.7.3'
+gem 'timers', '4.0.1'
+gem 'retryable', '2.0.1'
+gem 'minitar', '~> 0.5.4'
+gem 'octokit', '~> 3.0'
+gem 'ridley', '4.2.0'
+gem 'solve', '~> 1.1'
+gem 'thor', '~> 0.19'

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,4 +11,7 @@ version '0.1.0'
 end
 
 depends 'composer'
-depends 'php'
+# 1.7.0 introduces a breaking change regarding the quoting of attribute values - prevent updating
+# past 1.6.x until we have implemented some wrapping/warning and/or introduced a breaking
+# version of this cookbook to prevent unexpected production php config changes
+depends 'php', '~>1.6.0'

--- a/spec/composer_spec.rb
+++ b/spec/composer_spec.rb
@@ -4,16 +4,16 @@ describe 'ingenerator-php::composer' do
   let (:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
   
   it "installs composer as a global binary" do
-    chef_run.should ChefSpec::Matchers::ResourceMatcher.new(:composer, :install, chef_run.node['composer']['install_path'])
+    expect(chef_run).to ChefSpec::Matchers::ResourceMatcher.new(:composer, :install, chef_run.node['composer']['install_path'])
   end
   
   it "updates to the most recent composer if required" do
-    chef_run.should ChefSpec::Matchers::ResourceMatcher.new(:composer, :update, chef_run.node['composer']['install_path'])
+    expect(chef_run).to ChefSpec::Matchers::ResourceMatcher.new(:composer, :update, chef_run.node['composer']['install_path'])
   end
   
   it "creates a shared composer cache directory owned by the configured user" do
     config = chef_run.node['composer']['global_cache']
-    chef_run.should create_directory(config['path']).with(
+    expect(chef_run).to create_directory(config['path']).with(
       user:      config['user'],
       group:     config['group'],
       recursive: true
@@ -22,23 +22,23 @@ describe 'ingenerator-php::composer' do
   
   it "makes the shared composer cache world-writeable" do
     config = chef_run.node['composer']['global_cache']
-    chef_run.should create_directory(config['path']).with(
+    expect(chef_run).to create_directory(config['path']).with(
       mode:      0777
     )
   end
   
   context "when defining configuration" do
     it "sets the composer global install path to /usr/local/bin" do
-      chef_run.node['composer']['install_path'].should eq('/usr/local/bin')
+      expect(chef_run.node['composer']['install_path']).to eq('/usr/local/bin')
     end
     
     it "sets the composer cache path to /var/composer/cache" do
-      chef_run.node['composer']['global_cache']['path'].should eq('/var/composer/cache')
+      expect(chef_run.node['composer']['global_cache']['path']).to eq('/var/composer/cache')
     end
     
     it "sets the composer cache to be owned by root" do
-      chef_run.node['composer']['global_cache']['user'].should eq('root')
-      chef_run.node['composer']['global_cache']['group'].should eq('root')
+      expect(chef_run.node['composer']['global_cache']['user']).to eq('root')
+      expect(chef_run.node['composer']['global_cache']['group']).to eq('root')
     end
   end
   

--- a/spec/composer_spec.rb
+++ b/spec/composer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'ingenerator-php::composer' do
-  let (:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+  let (:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
   
   it "installs composer as a global binary" do
     chef_run.should ChefSpec::Matchers::ResourceMatcher.new(:composer, :install, chef_run.node['composer']['install_path'])

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'ingenerator-php::default' do
-  let (:chef_run) { ChefSpec::Runner.new.converge 'ingenerator-php::default' }
+  let (:chef_run) { ChefSpec::SoloRunner.new.converge 'ingenerator-php::default' }
 
   it 'should run the install_php recipe' do
     chef_run.should include_recipe 'ingenerator-php::install_php'
@@ -21,7 +21,7 @@ describe 'ingenerator-php::default' do
 
   context 'with node[project][install_dev_tools] set' do
     let (:chef_run) do
-      ChefSpec::Runner.new do |node|
+      ChefSpec::SoloRunner.new do |node|
         node.set['project']['install_dev_tools'] = true
       end.converge(described_recipe)
     end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -4,19 +4,19 @@ describe 'ingenerator-php::default' do
   let (:chef_run) { ChefSpec::SoloRunner.new.converge 'ingenerator-php::default' }
 
   it 'should run the install_php recipe' do
-    chef_run.should include_recipe 'ingenerator-php::install_php'
+    expect(chef_run).to include_recipe 'ingenerator-php::install_php'
   end
 
   it 'should run the share_inis recipe' do
-    chef_run.should include_recipe 'ingenerator-php::share_inis'
+    expect(chef_run).to include_recipe 'ingenerator-php::share_inis'
   end
 
   it 'should run the composer recipe' do
-    chef_run.should include_recipe 'ingenerator-php::composer'
+    expect(chef_run).to include_recipe 'ingenerator-php::composer'
   end
 
   it 'should not run the dev_tools recipe by default' do
-    chef_run.should_not include_recipe 'ingenerator-php::dev_tools'
+    expect(chef_run).not_to include_recipe 'ingenerator-php::dev_tools'
   end
 
   context 'with node[project][install_dev_tools] set' do
@@ -27,7 +27,7 @@ describe 'ingenerator-php::default' do
     end
 
     it "should run the dev_tools recipe" do
-      chef_run.should include_recipe 'ingenerator-php::dev_tools'
+      expect(chef_run).to include_recipe 'ingenerator-php::dev_tools'
     end
   end
 

--- a/spec/dev_tools_spec.rb
+++ b/spec/dev_tools_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'ingenerator-php::dev_tools' do
-  let (:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+  let (:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
   it "installs xdebug as a package" do
     chef_run.should install_package('php5-xdebug')
@@ -9,7 +9,7 @@ describe 'ingenerator-php::dev_tools' do
 
   context "with configured CLI debugging options" do
     let (:chef_run) do
-      ChefSpec::Runner.new do |node|
+      ChefSpec::SoloRunner.new do |node|
         node.set['php']['xdebug']['idekey'] = 'FOO'
         node.set['php']['xdebug']['ide_server_name'] = 'foo_server'
       end.converge(described_recipe)

--- a/spec/dev_tools_spec.rb
+++ b/spec/dev_tools_spec.rb
@@ -4,7 +4,7 @@ describe 'ingenerator-php::dev_tools' do
   let (:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
   it "installs xdebug as a package" do
-    chef_run.should install_package('php5-xdebug')
+    expect(chef_run).to install_package('php5-xdebug')
   end
 
   context "with configured CLI debugging options" do
@@ -16,30 +16,30 @@ describe 'ingenerator-php::dev_tools' do
     end
 
     it "installs the xdebug wrapper command as an executable" do
-      chef_run.should create_template('/usr/local/bin/xdebug').with(
+      expect(chef_run).to create_template('/usr/local/bin/xdebug').with(
         mode: 0755
       )
-      chef_run.should render_file('/usr/local/bin/xdebug').with_content(/^#!\/bin\/bash/)
+      expect(chef_run).to render_file('/usr/local/bin/xdebug').with_content(/^#!\/bin\/bash/)
     end
 
     it "sets the xdebug idekey from the node attributes" do
-      chef_run.should render_file('/usr/local/bin/xdebug').with_content(/^export XDEBUG_CONFIG="idekey=FOO"$/m)
+      expect(chef_run).to render_file('/usr/local/bin/xdebug').with_content(/^export XDEBUG_CONFIG="idekey=FOO"$/m)
     end
 
     it "sets the IDE server name from the node attributes" do
-      chef_run.should render_file('/usr/local/bin/xdebug').with_content(/^export PHP_IDE_CONFIG="serverName=foo_server"$/m)
+      expect(chef_run).to render_file('/usr/local/bin/xdebug').with_content(/^export PHP_IDE_CONFIG="serverName=foo_server"$/m)
     end
   end
   
   context "with default CLI debugging options" do
     it "sets the xdebug idekey to PHPSTORM" do
-      chef_run.should render_file('/usr/local/bin/xdebug').with_content(/^export XDEBUG_CONFIG="idekey=PHPSTORM"$/m)
+      expect(chef_run).to render_file('/usr/local/bin/xdebug').with_content(/^export XDEBUG_CONFIG="idekey=PHPSTORM"$/m)
     end
     
     it "sets the xdebug server name to the hostname" do
       hostname = chef_run.node['hostname']
       pattern = Regexp.new('^export PHP_IDE_CONFIG="serverName='+Regexp.escape(hostname)+'"$', Regexp::MULTILINE)
-      chef_run.should render_file('/usr/local/bin/xdebug').with_content(pattern)
+      expect(chef_run).to render_file('/usr/local/bin/xdebug').with_content(pattern)
     end
     
   end

--- a/spec/install_php_spec.rb
+++ b/spec/install_php_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'ingenerator-php::install_php' do
-  let (:chef_run) { ChefSpec::Runner.new.converge 'ingenerator-php::install_php' }
+  let (:chef_run) { ChefSpec::SoloRunner.new.converge 'ingenerator-php::install_php' }
 
   it "installs php from package with the community cookbook recipe" do
     chef_run.should include_recipe "php::package"
@@ -29,7 +29,7 @@ describe 'ingenerator-php::install_php' do
 
   context "when session.save_path is provided" do
     let (:chef_run) do
-      ChefSpec::Runner.new do |node|
+      ChefSpec::SoloRunner.new do |node|
         node.set['php']['directives']['session.save_path'] = '/tmp/foo/sessions'
         node.set['php']['session_dir']['user']  = 'foo-user'
         node.set['php']['session_dir']['group'] = 'bar-group'
@@ -59,7 +59,7 @@ describe 'ingenerator-php::install_php' do
 
   context "with optional modules in node attributes" do
       let (:chef_run) do
-        ChefSpec::Runner.new do |node|
+        ChefSpec::SoloRunner.new do |node|
           node.set['php']['module_packages']['php-gd'] = true
           node.set['php']['module_packages']['php-apc'] = false
         end.converge(described_recipe)

--- a/spec/install_php_spec.rb
+++ b/spec/install_php_spec.rb
@@ -4,27 +4,27 @@ describe 'ingenerator-php::install_php' do
   let (:chef_run) { ChefSpec::SoloRunner.new.converge 'ingenerator-php::install_php' }
 
   it "installs php from package with the community cookbook recipe" do
-    chef_run.should include_recipe "php::package"
+    expect(chef_run).to include_recipe "php::package"
   end
 
   it "does not update pear.php.net" do
     # these are slow and are not a required part of installing php especially as we now use composer
-    chef_run.should_not ChefSpec::Matchers::ResourceMatcher.new(:php_pear_channel, :update, 'pear.php.net')
+    expect(chef_run).not_to ChefSpec::Matchers::ResourceMatcher.new(:php_pear_channel, :update, 'pear.php.net')
   end
 
   it "does not update pecl.php.net" do
-    chef_run.should_not ChefSpec::Matchers::ResourceMatcher.new(:php_pear_channel, :update, 'pecl.php.net')
+    expect(chef_run).not_to ChefSpec::Matchers::ResourceMatcher.new(:php_pear_channel, :update, 'pecl.php.net')
   end
 
   it "writes a common php.ini in /etc/php5/php.ini" do
-    chef_run.should render_file('/etc/php5/php.ini').with_content(/About php.ini/)
+    expect(chef_run).to render_file('/etc/php5/php.ini').with_content(/About php.ini/)
   end
 
   it "includes custom directives in the php.ini file" do
     chef_run.node.set['php']['directives']['session.save_path'] = '/tmp/sessions'
     chef_run.converge(described_recipe)
 
-    chef_run.should render_file('/etc/php5/php.ini').with_content(/session.save_path="\/tmp\/sessions"/)
+    expect(chef_run).to render_file('/etc/php5/php.ini').with_content(/session.save_path="\/tmp\/sessions"/)
   end
 
   context "when session.save_path is provided" do
@@ -37,11 +37,11 @@ describe 'ingenerator-php::install_php' do
     end
 
     it "ensures the path exists" do
-      chef_run.should create_directory('/tmp/foo/sessions').with(recursive: true)
+      expect(chef_run).to create_directory('/tmp/foo/sessions').with(recursive: true)
     end
 
     it "ensures the path is private to the user and group specified in node['php']['session_dir']" do
-      chef_run.should create_directory('/tmp/foo/sessions').with(
+      expect(chef_run).to create_directory('/tmp/foo/sessions').with(
         user:  'foo-user',
         group: 'bar-group',
         mode:  0700
@@ -50,11 +50,11 @@ describe 'ingenerator-php::install_php' do
   end
 
   it "installs the php-apc module from package" do
-    chef_run.should install_package "php-apc"
+    expect(chef_run).to install_package "php-apc"
   end
 
   it "installs the php5-curl module from package" do
-    chef_run.should install_package "php5-curl"
+    expect(chef_run).to install_package "php5-curl"
   end
 
   context "with optional modules in node attributes" do
@@ -66,11 +66,11 @@ describe 'ingenerator-php::install_php' do
       end
 
       it "installs packages for required modules" do
-        chef_run.should install_package 'php-gd'
+        expect(chef_run).to install_package 'php-gd'
       end
 
       it "does not install packages for modules that are disabled" do
-        chef_run.should_not install_package 'php-apc'
+        expect(chef_run).not_to install_package 'php-apc'
       end
   end
 

--- a/spec/share_inis_spec.rb
+++ b/spec/share_inis_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'ingenerator-php::share_inis' do
   let (:chef_run) do
-    ChefSpec::Runner.new do |node|
+    ChefSpec::SoloRunner.new do |node|
       node.set['php']['share_env_inis']['/etc/php5/cgi/php.ini'] = false
       node.set['php']['share_env_inis']['/etc/php5/apache2/php.ini'] = true
     end.converge(described_recipe)
@@ -53,14 +53,14 @@ describe 'ingenerator-php::share_inis' do
   end
 
   context "with default configuration" do
-    let (:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+    let (:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
     it "shares configuration for CLI" do
-      chef_run.node['php']['share_env_inis']['/etc/php5/cli/php.ini'].should be_true
+      chef_run.node['php']['share_env_inis']['/etc/php5/cli/php.ini'].should be true
     end
 
     it "shares configuration for CGI" do
-      chef_run.node['php']['share_env_inis']['/etc/php5/cgi/php.ini'].should be_true
+      chef_run.node['php']['share_env_inis']['/etc/php5/cgi/php.ini'].should be true
     end
 
     it "does not contain configuration for apache" do

--- a/spec/share_inis_spec.rb
+++ b/spec/share_inis_spec.rb
@@ -13,33 +13,33 @@ describe 'ingenerator-php::share_inis' do
   context "when node['share_env_inis'][filename] is true" do
     context "and the file has not yet been replaced with a link" do
       before(:each) do
-        File.stub('symlink?').and_return true
-        File.stub('symlink?').with('/etc/php5/apache2/php.ini').and_return false
+        allow(File).to receive('symlink?').and_return true
+        allow(File).to receive('symlink?').with('/etc/php5/apache2/php.ini').and_return false
       end
 
       it "removes old static ini files" do
-        chef_run.should delete_file('/etc/php5/apache2/php.ini')
+        expect(chef_run).to delete_file('/etc/php5/apache2/php.ini')
       end
 
       it "links ini file path to the shared ini file" do
-        chef_run.should create_link('/etc/php5/apache2/php.ini')
+        expect(chef_run).to create_link('/etc/php5/apache2/php.ini')
         link = chef_run.link('/etc/php5/apache2/php.ini')
-        link.should link_to("#{php_conf_dir}/php.ini")
+        expect(link).to link_to("#{php_conf_dir}/php.ini")
       end
     end
 
     context "and the file is already a symlink" do
       before(:each) do
-        File.stub('symlink?').and_return false
-        File.stub('symlink?').with('/etc/php5/apache2/php.ini').and_return(true)
+        allow(File).to receive('symlink?').and_return false
+        allow(File).to receive('symlink?').with('/etc/php5/apache2/php.ini').and_return(true)
       end
 
       it "does not delete the file" do
-        chef_run.should_not delete_file('/etc/php5/apache2/php.ini')
+        expect(chef_run).not_to delete_file('/etc/php5/apache2/php.ini')
       end
 
       it "does not create a new link" do
-        chef_run.should_not create_link('/etc/php5/apache2/php.ini')
+        expect(chef_run).not_to create_link('/etc/php5/apache2/php.ini')
       end
 
     end
@@ -47,8 +47,8 @@ describe 'ingenerator-php::share_inis' do
 
   context "when node['share_env_inis'][filename] is false" do
     it "does not touch existing static ini files" do
-      chef_run.should_not delete_file('/etc/php5/cgi/php.ini')
-      chef_run.should_not create_link('/etc/php5/cgi/php.ini')
+      expect(chef_run).not_to delete_file('/etc/php5/cgi/php.ini')
+      expect(chef_run).not_to create_link('/etc/php5/cgi/php.ini')
     end
   end
 
@@ -56,15 +56,15 @@ describe 'ingenerator-php::share_inis' do
     let (:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
     it "shares configuration for CLI" do
-      chef_run.node['php']['share_env_inis']['/etc/php5/cli/php.ini'].should be true
+      expect(chef_run.node['php']['share_env_inis']['/etc/php5/cli/php.ini']).to be true
     end
 
     it "shares configuration for CGI" do
-      chef_run.node['php']['share_env_inis']['/etc/php5/cgi/php.ini'].should be true
+      expect(chef_run.node['php']['share_env_inis']['/etc/php5/cgi/php.ini']).to be true
     end
 
     it "does not contain configuration for apache" do
-      chef_run.node['php']['share_env_inis'].should_not have_key('/etc/php5/apache2/php.ini')
+      expect(chef_run.node['php']['share_env_inis']).not_to have_key('/etc/php5/apache2/php.ini')
     end
   end
 


### PR DESCRIPTION
Use a containerised travis build and update to the latest chefspec
version because the build will otherwise break.
