### PR TITLE
Update xdebug provisioning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem 'berkshelf',  '~> 3.0'
 gem 'ohai',       '~> 7.0'
 gem 'chefspec',   '4.3.0'
+gem 'chef-sugar'
 gem 'foodcritic', '~> 3.0'
 
 # All these things are required to make sure it works

--- a/attributes/xdebug.rb
+++ b/attributes/xdebug.rb
@@ -1,0 +1,4 @@
+# Xdebug attributes
+# Only relevant if the `project.install_dev_tools` attribute is set
+
+default['php']['xdebug']['version'] = '2.3.3'

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,6 +10,7 @@ version '0.1.0'
   supports os
 end
 
+depends 'chef-sugar', '>=1.2.6'
 depends 'composer'
 # 1.7.0 introduces a breaking change regarding the quoting of attribute values - prevent updating
 # past 1.6.x until we have implemented some wrapping/warning and/or introduced a breaking

--- a/recipes/dev_tools.rb
+++ b/recipes/dev_tools.rb
@@ -20,6 +20,14 @@
 # limitations under the License.
 #
 
+include_recipe 'chef-sugar::default'
+if vagrant?
+  node.default['php']['directives']['xdebug.remote_enable'] = 1
+  # assign default vagrant host IP for our vagrant IP range
+  node.default['php']['directives']['xdebug.remote_host']   = '10.87.23.1'
+  node.default['php']['directives']['xdebug.remote_log']    = '/tmp/xdebug_remote.log'
+end
+
 # Install the latest version of xdebug if required
 # @todo: could we skip the pecl update if we already have the right xdebug version?
 php_pear_channel 'pecl.php.net' do

--- a/recipes/dev_tools.rb
+++ b/recipes/dev_tools.rb
@@ -20,7 +20,16 @@
 # limitations under the License.
 #
 
-package 'php5-xdebug'
+# Install the latest version of xdebug if required
+# @todo: could we skip the pecl update if we already have the right xdebug version?
+php_pear_channel 'pecl.php.net' do
+  action :update
+end
+
+php_pear 'xdebug' do
+  action  :upgrade
+  version node['php']['xdebug']['version']
+end
 
 # Configure xdebug settings
 node.default['php']['xdebug']['idekey']          = 'PHPSTORM'

--- a/spec/dev_tools_spec.rb
+++ b/spec/dev_tools_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 describe 'ingenerator-php::dev_tools' do
   let (:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
+  it 'should run the chef_sugar recipe' do
+    expect(chef_run).to include_recipe 'chef-sugar::default'
+  end
+
   context "to install latest xdebug" do
 	let (:chef_run) do
 	  ChefSpec::SoloRunner.new do |node|
@@ -57,4 +61,29 @@ describe 'ingenerator-php::dev_tools' do
     end
     
   end
+
+  context "when running outside vagrant" do
+    before do
+	  expect(Chef::Sugar::Vagrant).to receive(:vagrant?).and_return(false)
+    end
+
+	it "does not initialise any xdebug directives" do
+	  expect(chef_run.node['php']['directives']).not_to have_key('xdebug.remote_enable')
+	  expect(chef_run.node['php']['directives']).not_to have_key('xdebug.remote_host')
+	  expect(chef_run.node['php']['directives']).not_to have_key('xdebug.remote_log')
+	end
+  end
+
+  context "when running under vagrant" do
+    before do
+      expect(Chef::Sugar::Vagrant).to receive(:vagrant?).and_return(true)
+    end
+
+    it "initialises xdebug to support remote debugging on ingenerator vagrant box" do
+      expect(chef_run.node['php']['directives']['xdebug.remote_enable']).to eq(1)
+      expect(chef_run.node['php']['directives']['xdebug.remote_host']).to eq('10.87.23.1')
+      expect(chef_run.node['php']['directives']['xdebug.remote_log']).to eq('/tmp/xdebug_remote.log')
+    end
+  end
+
 end

--- a/spec/dev_tools_spec.rb
+++ b/spec/dev_tools_spec.rb
@@ -3,8 +3,22 @@ require 'spec_helper'
 describe 'ingenerator-php::dev_tools' do
   let (:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
-  it "installs xdebug as a package" do
-    expect(chef_run).to install_package('php5-xdebug')
+  context "to install latest xdebug" do
+	let (:chef_run) do
+	  ChefSpec::SoloRunner.new do |node|
+		node.set['php']['xdebug']['version'] = '2.3.3'
+	  end.converge(described_recipe)
+	end
+
+    it "updates the pecl pear channel" do
+      expect(chef_run).to ChefSpec::Matchers::ResourceMatcher.new(:php_pear_channel, :update, 'pecl.php.net')
+    end
+
+    it "installs specified xdebug version from pecl" do
+      expect(chef_run).to ChefSpec::Matchers::ResourceMatcher.new(:php_pear, :upgrade, 'xdebug').with(
+        version:  '2.3.3',
+      )
+    end
   end
 
   context "with configured CLI debugging options" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
+require 'chef/sugar'
 
 RSpec.configure do |c|
   c.filter_run(focus: true)


### PR DESCRIPTION
The project can specify the xdebug version to use, by default
the most recent from the cookbook attributes will be provided
and installed/upgraded from pecl as required.
