### PR TITLE
Run `composer check-platform-reqs` before installing packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/). Note that
 
 ## Unreleased
 
+* Run composer check-platform-reqs before installing dependencies by default - you 
+  can disable this by setting the resource option if absolutely necessary but it 
+  would be better to fix either the packages you're installing or the runtime 
+  environment.
+
 ## 2.0.1 (2017-08-10)
 
 * Exclude unnecessary build-time files and dependencies from the vendored cookbook

--- a/test/cookbooks/test_helpers/recipes/test_composer_dependencies.rb
+++ b/test/cookbooks/test_helpers/recipes/test_composer_dependencies.rb
@@ -1,3 +1,4 @@
 composer_dependencies node['test']['project_dir'] do
-  run_as node['test']['run_as']
+  run_as              node['test']['run_as']
+  check_platform_reqs node['test']['check_requirements'] unless node['test']['check_requirements'].nil?
 end


### PR DESCRIPTION
This runs by default but you can opt out with the check_platform_reqs
option on the composer_dependencies resource.